### PR TITLE
MicrosoftTeams.initialize() is not synchronous and requires a callback

### DIFF
--- a/MonetizationCodeSample/TeamsTabApp/Views/Tab/Index.cshtml
+++ b/MonetizationCodeSample/TeamsTabApp/Views/Tab/Index.cshtml
@@ -25,12 +25,13 @@
         }
 
         $(function () {
-            microsoftTeams.initialize();
-            microsoftTeams.settings.registerOnSaveHandler(function (saveEvent) {
-                microsoftTeams.settings.setSettings(createTabSettings());
-                saveEvent.notifySuccess();
+            microsoftTeams.initialize(() => {
+                microsoftTeams.settings.registerOnSaveHandler(function (saveEvent) {
+                    microsoftTeams.settings.setSettings(createTabSettings());
+                    saveEvent.notifySuccess();
+                });
+                microsoftTeams.settings.setValidityState(true);
             });
-            microsoftTeams.settings.setValidityState(true)
         });
     </script>
 }


### PR DESCRIPTION
MicrosoftTeams.initialize() is not synchronous and requires a callback. It sometimes works without but is not reliable. This commit adds the callback.