### PR TITLE
microsoftTeams.initialize() is not synchronous

### DIFF
--- a/MonetizationCodeSample/TeamsTabApp/Views/Tab/Index.cshtml
+++ b/MonetizationCodeSample/TeamsTabApp/Views/Tab/Index.cshtml
@@ -25,12 +25,13 @@
         }
 
         $(function () {
-            microsoftTeams.initialize();
-            microsoftTeams.settings.registerOnSaveHandler(function (saveEvent) {
-                microsoftTeams.settings.setSettings(createTabSettings());
-                saveEvent.notifySuccess();
+            microsoftTeams.initialize(() => {
+                microsoftTeams.settings.registerOnSaveHandler(function (saveEvent) {
+                    microsoftTeams.settings.setSettings(createTabSettings());
+                    saveEvent.notifySuccess();
+                });
+                microsoftTeams.settings.setValidityState(true);
             });
-            microsoftTeams.settings.setValidityState(true)
         });
     </script>
 }


### PR DESCRIPTION
microsoftTeams.initialize() is not synchronous and may fail if you don't wait for callback
This PR fixes this for the Teams tab sample