### PR TITLE
Make appsource green, saas server blue for clearer demos

### DIFF
--- a/MonetizationCodeSample/AppSourceMockWebApp/wwwroot/css/site.css
+++ b/MonetizationCodeSample/AppSourceMockWebApp/wwwroot/css/site.css
@@ -1,6 +1,10 @@
 ﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
+body {
+    background-color: lightgreen;
+}
+
 a.navbar-brand {
     white-space: normal;
     text-align: center;

--- a/MonetizationCodeSample/SaaSSampleWebApp/wwwroot/css/site.css
+++ b/MonetizationCodeSample/SaaSSampleWebApp/wwwroot/css/site.css
@@ -12,6 +12,7 @@ body {
     flex-direction: column;
     color: #000;
     line-height: normal;
+    background-color: lightblue;
 }
 
 main {


### PR DESCRIPTION
It may be confusing for new devs to understand what is done by Appsource and what is done by the SaaS application. To make this crystal clear, this PR changes the background color of Appsource to light green and the SaaS app pages are light blue.