### PR TITLE
Updated linq to handle exception in user error

### DIFF
--- a/MonetizationCodeSample/SaaSSampleWebApi/Controllers/SubscriptionsController.cs
+++ b/MonetizationCodeSample/SaaSSampleWebApi/Controllers/SubscriptionsController.cs
@@ -221,7 +221,7 @@ namespace SaaSSampleWebApi.Controllers
             var userId = Guid.Parse(HttpContext.User.GetObjectId());
 
             var subscription = _licenseDbContext.Subscriptions.Where(subscription =>
-                subscription.OfferId == offerId && subscription.TenantId == tenantId).SingleOrDefault();
+                subscription.OfferId == offerId && subscription.TenantId == tenantId).FirstOrDefault();
 
             if (subscription == null)
             {


### PR DESCRIPTION
The appsource emulator allows users to subscribe more than one (being just a mock app store), adding additional entries in DB. 

At least in this scenario would it make sense to use **FirstOrDefault** instead of **SingleOrDefault** in order to avoid exception with confusing error message which indicates it is an authorization issue.
