### PR TITLE
added separate scripts to deploy saas resources only

### DIFF
--- a/Deployment_SaaS_Resources/ARMParameters.json
+++ b/Deployment_SaaS_Resources/ARMParameters.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "webAppSiteName": {
+      "value": "contosomonetizationwebapp"
+    },
+    "webApiSiteName": {
+      "value": "contosomonetizationwebapi"
+    },   
+    "resourceMockWebSiteName": {
+      "value": "contosomonetizationappsource"
+    },
+    "domainName": {
+      "value": "m365404404.onmicrosoft.com"
+    },
+    "directoryId": {
+      "value": "c5489ec7-a322-45cf-a170-7ce0bdb538c5"
+    },
+    "sqlAdministratorLogin": {
+      "value": "Monetizationadmin"
+    },
+    "sqlAdministratorLoginPassword": {
+      "value": "pass@Word2022"
+    },
+    "sqlMockDatabaseName": {
+      "value": "AppSourceMockWebAppDB"
+    },
+    "sqlSampleDatabaseName": {
+      "value": "MonetizationSampleDB"
+    },
+    "webAppClientId": {
+      "value": ""
+    },
+    "webAppClientSecret": {
+      "value": ""
+    },
+    "webApiClientId": {
+      "value": ""
+    },
+    "webApiClientSecret": {
+      "value": ""
+    },
+    "webApiIdentifierUri": {
+      "value": ""
+    },    
+    "sourceMockClientId": {
+      "value": ""
+    },
+    "tenantId": {
+      "value": "organizations"
+    }
+  }
+}

--- a/Deployment_SaaS_Resources/ARMTemplate.json
+++ b/Deployment_SaaS_Resources/ARMTemplate.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "webAppSiteName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the web app that you wish to create."
+      }
+    },
+    "webApiSiteName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the web api that you wish to create."
+      }
+    },
+    "resourceMockWebSiteName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the mocked resource site that you wish to create."
+      }
+    },
+    "domainName": {
+      "type": "string",
+      "metadata": {
+        "description": "Primary domain name"
+      }
+    },
+    "directoryId": {
+      "type": "string",
+      "metadata": {
+        "description": "Directory (tenant) ID"
+      }
+    },
+    "sqlAdministratorLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "The admin user of the SQL Server"
+      }
+    },
+    "sqlAdministratorLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the admin user of the SQL Server"
+      }
+    },
+    "sqlMockDatabaseName": {
+      "type": "string",
+      "defaultValue": "AppSourceMockWebAppDB",
+      "metadata": {
+        "description": "Database Name"
+      }
+    },
+    "sqlSampleDatabaseName": {
+      "type": "string",
+      "defaultValue": "MonetizationSampleDB",
+      "metadata": {
+        "description": "Database Name"
+      }
+    },
+    "webAppClientId": {
+      "type": "string"
+    },
+    "webAppClientSecret": {
+      "type": "string"
+    },
+    "webApiClientId": {
+      "type": "string"
+    },
+    "webApiClientSecret": {
+      "type": "string"
+    },
+      
+    "sourceMockClientId": {
+      "type": "string"
+    },
+    "webApiIdentifierUri": {
+      "type": "string"
+    },
+    "tenantId": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "hostingPlanName": "[concat('hostingplan', uniqueString(resourceGroup().id))]",
+    "sqlServerName": "[concat('sqlserver', uniqueString(resourceGroup().id))]",
+    "webApiBaseAddress": "[concat('https://', parameters('webApiSiteName'), '.azurewebsites.net')]",
+    "webAppBaseAddress": "[concat('https://', parameters('webAppSiteName'), '.azurewebsites.net')]",
+    "resourceMockBaseAddress": "[concat('https://', parameters('resourceMockWebSiteName'), '.azurewebsites.net')]"
+    
+  },
+  "resources": [
+    {
+      "name": "[variables('sqlServerName')]",
+      "type": "Microsoft.Sql/servers",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "SqlServer"
+      },
+      "apiVersion": "2014-04-01",
+      "properties": {
+        "administratorLogin": "[parameters('sqlAdministratorLogin')]",
+        "administratorLoginPassword": "[parameters('sqlAdministratorLoginPassword')]",
+        "version": "12.0"
+      },
+      "resources": [
+        {
+          "name": "[parameters('sqlMockDatabaseName')]",
+          "type": "databases",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "Database"
+          },
+          "apiVersion": "2014-04-01",
+          "dependsOn": ["[variables('sqlServerName')]"],
+          "properties": {
+            "edition": "Basic",
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "name": "[parameters('sqlSampleDatabaseName')]",
+          "type": "databases",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "Database"
+          },
+          "apiVersion": "2014-04-01",
+          "dependsOn": ["[variables('sqlServerName')]"],
+          "properties": {
+            "edition": "Basic",
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "type": "firewallRules",
+          "apiVersion": "2014-04-01",
+          "dependsOn": ["[variables('sqlServerName')]"],
+          "location": "[resourceGroup().location]",
+          "name": "AllowAllWindowsAzureIps",
+          "properties": {
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
+          }
+        }
+      ]
+    },
+    {
+      "apiVersion": "2018-02-01",
+      "name": "[variables('hostingPlanName')]",
+      "type": "Microsoft.Web/serverfarms",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "HostingPlan"
+      },
+      "sku": {
+        "tier": "Basic",
+        "name": "B1"
+      },
+      "properties": {
+        "name": "[variables('hostingPlanName')]"
+      }
+    },
+    {
+      "apiVersion": "2018-02-01",
+      "name": "[parameters('webAppSiteName')]",
+      "type": "Microsoft.Web/sites",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[variables('hostingPlanName')]"],
+      "tags": {
+        "[concat('hidden-related:', resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName')))]": "empty",
+        "displayName": "Website"
+      },
+      "properties": {
+        "name": "[parameters('webAppSiteName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "siteConfig": {
+          "alwaysOn": false
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2018-02-01",
+          "type": "config",
+          "name": "appsettings",
+          "dependsOn": ["[parameters('webAppSiteName')]"],
+          "properties": {
+            "AzureAd:Domain": "[parameters('domainName')]",
+            "AzureAd:DirectoryId": "[parameters('directoryId')]",
+            "AzureAd:TenantId": "[parameters('tenantId')]",
+            "AzureAd:ClientId": "[parameters('webAppClientId')]",
+            "AzureAd:ClientSecret": "[parameters('webAppClientSecret')]",
+            "SaaSWebApi:Scopes": "[concat(parameters('webApiIdentifierUri'),'/user_impersonation')]",
+            "SaaSWebApi:BaseAddress": "[variables('webApiBaseAddress')]",
+            "AppSource": "[concat(variables('resourceMockBaseAddress'), '/')]"
+          }
+        }
+      ]
+    },
+    {
+      "apiVersion": "2018-02-01",
+      "name": "[parameters('webApiSiteName')]",
+      "type": "Microsoft.Web/sites",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[variables('hostingPlanName')]"],
+      "tags": {
+        "[concat('hidden-related:', resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName')))]": "empty",
+        "displayName": "Website"
+      },
+      "properties": {
+        "name": "[parameters('webApiSiteName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "siteConfig": {
+          "alwaysOn": false
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2018-02-01",
+          "type": "config",
+          "name": "connectionstrings",
+          "dependsOn": [
+            "[parameters('webApiSiteName')]",
+            "[variables('sqlServerName')]"
+          ],
+          "properties": {
+            "DefaultConnection": {
+              "value": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', parameters('sqlSampleDatabaseName'), ';User Id=', parameters('sqlAdministratorLogin'), '@', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlAdministratorLoginPassword'), ';')]",
+              "type": "SQLAzure"
+            }
+          }
+        },
+        {
+          "apiVersion": "2018-02-01",
+          "type": "config",
+          "name": "appsettings",
+          "dependsOn": ["[parameters('webApiSiteName')]"],
+          "properties": {
+            "AzureAd:Domain": "[parameters('domainName')]",
+            "AzureAd:TenantId": "[parameters('tenantId')]",
+            "AzureAd:ClientId": "[parameters('webApiClientId')]",
+            "AzureAd:ClientSecret": "[parameters('webApiClientSecret')]",
+            "SaaSfulfillmentAPIs:ApiEndPoint": "[variables('resourceMockBaseAddress')]",
+            "SaaSfulfillmentAPIs:ApiVersion": "2018-09-15"
+          }
+        }
+      ]
+    },
+
+    {
+      "apiVersion": "2018-02-01",
+      "name": "[parameters('resourceMockWebSiteName')]",
+      "type": "Microsoft.Web/sites",
+      "location": "[resourceGroup().location]",
+      "dependsOn": ["[variables('hostingPlanName')]"],
+      "tags": {
+        "[concat('hidden-related:', resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName')))]": "empty",
+        "displayName": "Website"
+      },
+      "properties": {
+        "name": "[parameters('resourceMockWebSiteName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "siteConfig": {
+          "alwaysOn": false
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2018-02-01",
+          "type": "config",
+          "name": "connectionstrings",
+          "dependsOn": [
+            "[parameters('resourceMockWebSiteName')]",
+            "[variables('sqlServerName')]"
+          ],
+          "properties": {
+            "DefaultConnection": {
+              "value": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', parameters('sqlMockDatabaseName'), ';User Id=', parameters('sqlAdministratorLogin'), '@', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlAdministratorLoginPassword'), ';')]",
+              "type": "SQLAzure"
+            }
+          }
+        },
+        {
+          "apiVersion": "2018-02-01",
+          "type": "config",
+          "name": "appsettings",
+          "dependsOn": ["[parameters('resourceMockWebSiteName')]"],
+          "properties": {
+            "AzureAd:Domain": "[parameters('domainName')]",
+            "AzureAd:TenantId": "[parameters('tenantId')]",
+            "AzureAd:ClientId": "[parameters('sourceMockClientId')]",
+            "SaaSOffer:LandingpageURL": "[concat(variables('webAppBaseAddress'),'/Fulfilment')]",
+            "SaaSOffer:Connectionwebhook": "[concat(variables('webApiBaseAddress'),'/api/webhook')]"
+          }
+        }
+      ]
+    }
+  
+  ],
+  "outputs": {
+    "webSiteUri": {
+      "type": "string",
+      "value": "[reference(concat('Microsoft.Web/sites/', parameters('webAppSiteName'))).hostnames[0]]"
+    },
+    "sqlSvrFqdn": {
+      "type": "string",
+      "value": "[reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName]"
+    }
+  }
+}

--- a/Deployment_SaaS_Resources/AadApps.config.json
+++ b/Deployment_SaaS_Resources/AadApps.config.json
@@ -1,0 +1,121 @@
+{
+  "apps": [
+    {
+      "appName": "webApp",
+      "passwordCredential": {
+        "displayName": "devKey"
+      },
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample Web App",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "Id": "0e263e50-5827-48a4-b97c-d940288653c7",
+                "Type": "Scope"
+              },
+              {
+                "Id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "Type": "Scope"
+              }
+            ]
+          }
+        ],
+        "Web": {
+          "ImplicitGrantSettings": {
+            "EnableAccessTokenIssuance": true,
+            "EnableIdTokenIssuance": true
+          },
+          "RedirectUris": ["https://localhost:44310/", "https://localhost:44310/signin-oidc", "https://localhost:44310/home/SPHostedAddinEmbedContent"]
+        }
+      }
+    },
+    {
+      "appName": "webApi",
+      "passwordCredential": {
+        "displayName": "devKey"
+      },
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample Web API",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "Id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "Type": "Scope"
+              },
+              {
+                "Id": "7427e0e9-2fba-42fe-b0c0-848c9e6a8182",
+                "Type": "Scope"
+              },
+              {
+                "Id": "37f7f235-527c-4136-accd-4a02d197296e",
+                "Type": "Scope"
+              },
+              {
+                "Id": "14dad69e-099b-42c9-810b-d002981feec1",
+                "Type": "Scope"
+              },
+              {
+                "Id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "Type": "Scope"
+              }
+            ]
+          }
+        ],
+        "Api": {
+          "Oauth2PermissionScopes": [{
+            "AdminConsentDescription": "Accesses Contoso Monetization WebAPI as an admin",
+            "AdminConsentDisplayName": "Access ContosoMonetizationWebAPI as an admin",
+            "UserConsentDisplayName": "Access ContosoMonetizationWebAPI as a user",
+            "UserConsentDescription": "Accesses Contoso Monetization WebAPI as a user",
+            "Id": "0cdca35a-e16c-4d79-9751-c353ae328f93",
+            "IsEnabled": true,
+            "Type": "User",
+            "Value": "user_impersonation"
+          }]
+        }
+      }
+    },  
+    {
+      "appName": "appResource",
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample App source",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "type": "Scope"
+              },
+              {
+                "id": "37f7f235-527c-4136-accd-4a02d197296e",
+                "type": "Scope"
+              },
+              {
+                "id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "type": "Scope"
+              },
+              {
+                "id": "14dad69e-099b-42c9-810b-d002981feec1",
+                "type": "Scope"
+              }
+            ]
+          }
+        ],
+        "Web": {
+          "ImplicitGrantSettings": {
+            "EnableIdTokenIssuance": true
+          },
+          "RedirectUris": ["https://localhost:44381/", "https://localhost:44381/signin-oidc"]
+        }
+      }
+    }   
+  ]
+}

--- a/Deployment_SaaS_Resources/DeployTemplate.ps1
+++ b/Deployment_SaaS_Resources/DeployTemplate.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+  [Parameter(Mandatory)]
+  [String]$resourceGroupName = (Read-Host -Prompt "Enter the Resource Group name")
+)
+
+#central us contains all required resources
+$location = "centralus"
+
+try {
+  Write-Host "Creating resource group..." -ForegroundColor Green
+  $resourceGroup = New-AzResourceGroup -Name $resourceGroupName -Location $location
+  
+  Write-Host "Deploying resource..." -ForegroundColor Green
+  $deployedResult =New-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName `
+    -TemplateFile ".\ARMTemplate.json" `
+    -TemplateParameterFile ".\ARMParameters.json"
+  Write-Host "Completed!"  -ForegroundColor Green
+}
+catch {
+  Write-Host $_.Exception.Message
+  Write-Host $_.Exception.ItemName
+}

--- a/Deployment_SaaS_Resources/DeploymentGuide.MD
+++ b/Deployment_SaaS_Resources/DeploymentGuide.MD
@@ -1,0 +1,119 @@
+# Installation Guide
+
+## Prerequisites
+
+- Install [PowerShell 7](https://github.com/PowerShell/PowerShell/releases/tag/v7.1.4)
+- Install the following PowerShell modules:
+  - [Microsoft Graph PowerShell SDK](https://github.com/microsoftgraph/msgraph-sdk-powershell#powershell-gallery)
+
+      ``` command
+      Install-Module Microsoft.Graph -AllowClobber -Force
+      ```
+
+  - [Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-6.4.0#installation)
+
+      ``` command
+      Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -AllowClobber -Force 
+      ```
+  
+- [Visual Studio 2019](https://visualstudio.microsoft.com/vs/)
+   >**Note:** use **Visual Studio Installer** to install the following development toolsets:
+  - ASP.NET and web development
+  - Azure development
+  - Office/SharePoint development
+  - .NET cross-platform development
+- [Visual Studio Code](https://code.visualstudio.com)
+- Install [.NET Framework 4.8 Developer Pack](https://dotnet.microsoft.com/download/dotnet-framework/thank-you/net48-developer-pack-offline-installer)
+- Install [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet/3.1)
+- Install [Microsoft Teams for work or school](https://www.microsoft.com/en-us/microsoft-teams/download-app)
+- Install [Node.js v14.18.1](https://nodejs.org/download/release/v14.18.1/)
+- Install [gulp-cli](https://www.npmjs.com/package/gulp-cli)
+
+   ``` command
+   npm install gulp-cli --global
+   ```
+
+- Download and setup [ngrok](https://dashboard.ngrok.com/get-started/setup)
+- Azure subscription and an admin account
+- Office 365 Tenant and a Global Admin account
+
+## Configure ARM Parameters
+
+1. Open the `ARMParameters.json` file and update the following parameters with values you choose.
+   > **Note:** a. You need to make sure enter a unique name for each web app and web site in the parameter list shown below because the script will create many Azure web apps and sites and each one must have a unique name.  All of the parameters that correspond to web apps and sites in the following list end in **SiteName**.
+   b. For domainName and directoryId, please refer to this [article](https://docs.microsoft.com/en-us/partner-center/find-ids-and-domain-names#find-the-microsoft-azure-ad-tenant-id-and-primary-domain-name) to find your Microsoft Azure AD tenant ID and primary domain name.
+
+    - webAppSiteName
+    - webApiSiteName
+    - resourceMockWebSiteName
+    - domainName
+    - directoryId (Directory (tenant) ID)
+    - sqlAdministratorLogin
+    - sqlAdministratorLoginPassword
+    - sqlMockDatabaseName
+    - sqlSampleDatabaseName
+
+## Create the Azure AD applications
+
+This sample uses three Azure Active Directory applications.
+
+- Contoso Monetization Code Sample Web App
+- Contoso Monetization Code Sample Web API
+- Contoso Monetization Code Sample App source
+
+1. In a Powershell 7 window, change to the **.\Deployment_SaaS_Resources** directory.
+
+1. In the same window run `Connect-Graph -Scopes "Application.ReadWrite.All, Directory.AccessAsUser.All DelegatedPermissionGrant.ReadWrite.All Directory.ReadWrite.All"`
+
+1. Click **Accept**.
+
+   ![Code Path](Images/5.png)
+
+1. In the same window run `.\InstallApps.ps1`
+
+1. Create and configure Azure AD apps successfully.
+
+   ![Code Path](Images/14.png)
+
+1. Copy the values from the output and later you will need some of these values to update the code and config file for deploying Add-ins.
+
+## Deploy the ARM template with PowerShell
+
+1. Open PowerShell 7 and run the Powershell command `Connect-AzAccount`.
+
+   ![Code Path](Images/7.png)
+
+1. Run the script `.\DeployTemplate.ps1`. When prompted, enter the name of the resource group to create.
+
+   ![Code Path](Images/8.png)
+
+1. Deploy ARM Template successfully.
+
+   ![Code Path](Images/9.png)
+
+## Compile and deploy the server code
+
+  >**Note:** Please make sure that the default NuGet package source **https://api.nuget.org/v3/index.json** is correctly added in Visual Studio 2019.
+
+  ![Code Path](Images/23.png)
+
+1. In the command line, change to the **.\MonetizationCodeSample** directory.
+
+1. Run the script `.\PublishSaaSApps.ps1`.
+
+1. When prompted, enter the same resource group name.
+
+1. Deploy code successfully.
+
+    >**Note:** You may see some warnings about file expiration, please ignore.
+
+   ![Code Path](Images/10.png)
+
+## Clean up
+
+If you want to remove all Azure AD applications and sites, you can do the following:
+
+1. Open PowerShell 7 and go to the **.\Deployment_SaaS_Resources** directory.
+1. Run the Powershell command `Remove-AzResourceGroup -name <resource group name>` and pay attention to replacing **&lt;resource group name&gt;** with your resource group name.
+1. Go to the **.\Deployment_SaaS_Resources** directory.
+1. Run the script `.\RemoveApps.ps1`.

--- a/Deployment_SaaS_Resources/InstallApps.ps1
+++ b/Deployment_SaaS_Resources/InstallApps.ps1
@@ -1,0 +1,111 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [String]$appsConfig = ".\AadApps.config.json",
+    [String]$armConfig = ".\ARMParameters.json"
+  
+
+)
+
+$appsJson = Get-Content -Path $appsConfig |Out-String|ConvertFrom-Json -AsHashtable
+$armConfigJson= Get-Content -Path $armConfig |Out-String|ConvertFrom-Json -AsHashtable
+
+$result = @{}
+
+foreach ($app in $appsJson.apps)
+{
+    $newApp = New-MgApplication -DisplayName $app.bodyParameter.displayName `
+                             -RequiredResourceAccess $app.bodyParameter.requiredResourceAccess `
+                             -SignInAudience $app.bodyParameter.signInAudience `
+                             -Web:$app.bodyParameter.Web `
+                             -Api:$app.bodyParameter.Api
+
+    
+    if ($app.passwordCredential) {
+        Start-Sleep -s 3
+        $password = Add-MgApplicationPassword -ApplicationId $newApp.Id -BodyParameter $app.passwordCredential
+    }
+    Start-Sleep -s 3
+
+    $newAppSP = New-MgServicePrincipal -AppId $newApp.AppId
+
+    $result.Add($app.appName, @{"id" = $newApp.Id; "appId"=$newApp.AppId; "spId"=$newAppSP.Id; "appSecret"=$password.SecretText; "requiredResourceAccess"=$app.bodyParameter.requiredResourceAccess})
+
+    Write-Host $newApp.DisplayName "application is created."
+}
+
+#Expose webApi to apps
+$webApiConfig = $appsJson.apps |Where-Object {$_.appName -eq "webApi"}
+$webApiPermissionId = $webApiConfig.bodyParameter.Api.Oauth2PermissionScopes.Id
+$preAuthorizedWebApi1=@{AppId=$result.webApp.AppId;DelegatedPermissionIds=@($webApiPermissionId)};
+$preAuthorizedWebApps = @($preAuthorizedWebApi1);
+
+$api = @{ 
+    "PreAuthorizedApplications"=$preAuthorizedWebApps;
+    "KnownClientApplications"=@($result.webApp.appId)
+}
+
+Update-MgApplication -ApplicationId $result.webApi.id -Api $api -IdentifierUris "api://$($result.webApi.appId)"
+$newWebApi = Get-MgApplication -ApplicationId $result.webApi.id
+$result.webApi.identifierUris = $newWebApi.IdentifierUris
+
+$exposedResource = @{
+    "resourceAppId"=$result.webApi.appId;
+    "resourceAccess"= @(@{"Id"= $webApiConfig.bodyParameter.Api.Oauth2PermissionScopes.Id ; "Type"="Scope"})
+}
+
+#Add Application permissions that are exposed from webApi and update RedirectUris
+$webAppRequired = @()
+$webAppRequired += $exposedResource
+$webAppRequired += $result.webApp.requiredResourceAccess
+$webAppSiteName = $armConfigJson.parameters.webAppSiteName.value
+$web = @{
+    "RedirectUris" = @("https://$webAppSiteName.azurewebsites.net/signin-oidc","https://$webAppSiteName.azurewebsites.net/","https://$webAppSiteName.azurewebsites.net/home/SPHostedAddinEmbedContent")
+}
+
+Update-MgApplication -ApplicationId $result.webApp.id -RequiredResourceAccess $webAppRequired -Web $web
+
+$resourceMockWebSiteName = $armConfigJson.parameters.resourceMockWebSiteName.value
+$web = @{
+    "RedirectUris" = @("https://$resourceMockWebSiteName.azurewebsites.net/signin-oidc","https://$resourceMockWebSiteName.azurewebsites.net/")
+}
+Update-MgApplication -ApplicationId $result.appResource.id -Web $web
+
+
+# grant consent
+$graphServicePrincipal = Get-MgServicePrincipal -Filter "AppId eq '00000003-0000-0000-c000-000000000000'"
+$null = New-MgOauth2PermissionGrant -ClientId $result.appResource.spId -ConsentType "AllPrincipals" -ResourceId $graphServicePrincipal.Id -Scope "email openid profile User.Read"
+$null = New-MgOauth2PermissionGrant -ClientId $result.webApp.spId -ConsentType "AllPrincipals" -ResourceId $graphServicePrincipal.Id -Scope "Directory.AccessAsUser.All User.Read"
+$null = New-MgOauth2PermissionGrant -ClientId $result.webApp.spId -ConsentType "AllPrincipals" -ResourceId $result.webApi.spId -Scope "user_impersonation"
+$null = New-MgOauth2PermissionGrant -ClientId $result.webApi.spId -ConsentType "AllPrincipals" -ResourceId $graphServicePrincipal.Id -Scope "email openid profile offline_access User.Read"
+
+# update ARMParameters.json 
+$armConfigJson.parameters.webAppClientId.value = $result.webApp.appId
+$armConfigJson.parameters.webAppClientSecret.value = $result.webApp.appSecret
+
+$armConfigJson.parameters.webApiClientId.value = $result.webApi.appId
+$armConfigJson.parameters.webApiClientSecret.value = $result.webApi.appSecret
+$armConfigJson.parameters.webApiIdentifierUri.value = $result.webApi.identifierUris[0]
+
+
+$armConfigJson.parameters.sourceMockClientId.value = $result.appResource.appId
+
+
+$armConfigJson | ConvertTo-Json -depth 32| set-content $armConfig
+
+
+Write-Host "WebApp ClientId: $($result.webApp.appId)" -ForegroundColor Green
+Write-Host "WebApp ClientSecret: $($result.webApp.appSecret)" -ForegroundColor Green
+Write-Host ""
+Write-Host "WebApi Id: $($result.webApi.appId)" -ForegroundColor Green
+Write-Host "WebApi ClientSecret: $($result.webApi.appSecret)" -ForegroundColor Green
+Write-Host "WebApi IdentifierUri: $($result.webApi.identifierUris)" -ForegroundColor Green
+Write-Host ""
+Write-Host ""
+Write-Host "appSource Id: $($result.appResource.appId)" -ForegroundColor Green
+Write-Host ""
+
+Write-Host "Completed!" -ForegroundColor White
+
+

--- a/Deployment_SaaS_Resources/NewApps.json
+++ b/Deployment_SaaS_Resources/NewApps.json
@@ -1,0 +1,107 @@
+{
+  "apps": [
+    {
+      "appName": "webApp",
+      "passwordCredential": {
+        "displayName": "devKey"
+      },
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample Web App Dev",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "Id": "0e263e50-5827-48a4-b97c-d940288653c7",
+                "Type": "Scope"
+              },
+              {
+                "Id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "Type": "Scope"
+              }
+            ]
+          }
+        ],
+        "implicitGrantSettingEnableIdTokenIssuance": true
+      }
+    },
+    {
+      "appName": "webApi",
+      "passwordCredential": {
+        "displayName": "devKey"
+      },
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample Web API Dev",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "Id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "Type": "Scope"
+              },
+              {
+                "Id": "7427e0e9-2fba-42fe-b0c0-848c9e6a8182",
+                "Type": "Scope"
+              },
+              {
+                "Id": "37f7f235-527c-4136-accd-4a02d197296e",
+                "Type": "Scope"
+              },
+              {
+                "Id": "14dad69e-099b-42c9-810b-d002981feec1",
+                "Type": "Scope"
+              },
+              {
+                "Id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "Type": "Scope"
+              }
+            ]
+          }
+        ],
+        "apiOauth2PermissionScopes": {
+          "userConsentDisplayName": "Access ContosoMonetizationWebAPI as a user",
+          "userConsentDescription": "Accesses Contoso Monetization WebAPI as a user",
+          "adminConsentDisplayName": "Access ContosoMonetizationWebAPI as an admin",
+          "adminConsentDescription": "Accesses Contoso Monetization WebAPI as an admin",
+          "id": "0cdca35a-e16c-4d79-9751-c353ae328f93",
+          "isEnabled": true,
+          "type": "User",
+          "Value": "user_impersonation"
+        }
+      }
+    },
+    {
+      "appName": "appResource",
+      "passwordCredential": {
+        "displayName": "devKey"
+      },
+      "bodyParameter": {
+        "displayName": "Contoso Monetization Code Sample App source Dev",
+        "signInAudience": "AzureADMultipleOrgs",
+        "requiredResourceAccess": [
+          {
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "resourceAccess": [
+              {
+                "Id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "Type": "Scope"
+              },
+              {
+                "Id": "37f7f235-527c-4136-accd-4a02d197296e",
+                "Type": "Scope"
+              },
+              {
+                "Id": "14dad69e-099b-42c9-810b-d002981feec1",
+                "Type": "Scope"
+              }
+            ]
+          }
+        ],
+        "implicitGrantSettingEnableIdTokenIssuance": true
+      }
+    }
+  ]
+}

--- a/Deployment_SaaS_Resources/NewApps.ps1
+++ b/Deployment_SaaS_Resources/NewApps.ps1
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [Parameter(Mandatory)]
+    [String]$config = (Read-Host -Prompt "Enter the config file")
+)
+
+
+$json = Get-Content -Path $config |Out-String|ConvertFrom-Json -AsHashtable
+$result = @{}
+
+foreach ($app in $json.apps)
+{
+    #$newApp = New-Application -BodyParameter $app.bodyParameter;
+    $newApp = New-MgApplication -DisplayName $app.bodyParameter.displayName `
+                             -RequiredResourceAccess $app.bodyParameter.requiredResourceAccess `
+                             -SignInAudience $app.bodyParameter.signInAudience `
+                             -ApiOauth2PermissionScopes $app.bodyParameter.apiOauth2PermissionScopes `
+                             -ImplicitGrantSettingEnableIdTokenIssuance:$app.bodyParameter.implicitGrantSettingEnableIdTokenIssuance
+
+    if ($app.passwordCredential){
+        $pwd = Add-MgApplicationPassword -ApplicationId $newApp.Id -BodyParameter $app.passwordCredential
+    }
+    $result.Add($app.appName, @{"id"=$newApp.Id; "appId"=$newApp.AppId; "appSecret"=$pwd.SecretText; "requiredResourceAccess"=$app.bodyParameter.requiredResourceAccess})
+}
+
+#Expose webApi to apps
+$webApiConfig = $json.apps |Where-Object {$_.appName -eq "webApi"}
+$webApiPermissionId = $webApiConfig.bodyParameter.apiOauth2PermissionScopes.id
+$preAuthorizedWebApi1=@{AppId=$result.webApp.AppId;PermissionIds=$webApiPermissionId};
+
+$preAuthorizedWebApi7=@{AppId=$result.appResource.AppId;PermissionIds=$webApiPermissionId};
+$preAuthorizedWebApis = @($preAuthorizedWebApi1,$preAuthorizedWebApi7);
+
+#Update-Application method has bug, the -ApplicationId parameter is id instead of appid.
+Update-MgApplication -ApplicationId $result.webApi.id -ApiPreAuthorizedApplications $preAuthorizedWebApis -IdentifierUris "api://$($result.webApi.appId)"
+$newWebApi = Get-MgApplication -ApplicationId $result.webApi.id
+$result.webApi.identifierUris = $newWebApi.IdentifierUris
+
+$exposedResource = @{
+    "resourceAppId"=$result.webApi.appId;
+    "resourceAccess"= @(@{"Id"= $webApiConfig.bodyParameter.apiOauth2PermissionScopes.id ; "Type"="Scope"})
+}
+
+#Add Application permissions that are exposed from webApi
+$webAppRequired = @()
+$webAppRequired += $exposedResource
+$webAppRequired += $result.webApp.requiredResourceAccess
+Update-MgApplication -ApplicationId $result.webApp.id -RequiredResourceAccess $webAppRequired
+
+$appResourceRequired = @()
+$appResourceRequired += $exposedResource
+$appResourceRequired += $result.appResource.requiredResourceAccess
+Update-MgApplication -ApplicationId $result.appResource.id -RequiredResourceAccess $appResourceRequired
+
+Write-Host "WebApp ClientId: $($result.webApp.appId)" -ForegroundColor Green
+Write-Host "WebApp ClientSecret: $($result.webApp.appSecret)" -ForegroundColor Green
+Write-Host ""
+Write-Host "WebApi Id: $($result.webApi.appId)" -ForegroundColor Green
+Write-Host "WebApi ClientSecret: $($result.webApi.appSecret)" -ForegroundColor Green
+Write-Host "WebApi IdentifierUri: $($result.webApi.identifierUris)" -ForegroundColor Green
+Write-Host ""
+
+Write-Host "appResource Id: $($result.appResource.appId)" -ForegroundColor Green
+Write-Host "Completed!" -ForegroundColor White
+#Consent manually

--- a/Deployment_SaaS_Resources/RemoveApps.ps1
+++ b/Deployment_SaaS_Resources/RemoveApps.ps1
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [String]$appsConfig = ".\AadApps.config.json"
+)
+
+$json = Get-Content -Path $appsConfig |Out-String|ConvertFrom-Json -AsHashtable
+
+foreach ($app in $json.apps)
+{
+    $filter = "DisplayName eq '" + $app.bodyParameter.displayName + "'"
+    Get-MgApplication -Filter $filter |ForEach-Object {
+        Remove-MgApplication -ApplicationId $_.Id
+        Write-Host "Remove $($app.bodyParameter.displayName)."
+    }
+}

--- a/Deployment_SaaS_Resources/UpdateApps.ps1
+++ b/Deployment_SaaS_Resources/UpdateApps.ps1
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [Parameter(Mandatory)]
+    [String]$armConfig = (Read-Host -Prompt "Enter the ARMParameters.json file")
+)
+
+$armConfigJson = Get-Content -Path $armConfig |Out-String|ConvertFrom-Json
+
+$webApp = Get-MgApplication -top 400|Where-Object {$_.AppId -eq $armConfigJson.parameters.webAppClientId.value}
+$webAppSiteName = $armConfigJson.parameters.webAppSiteName.value
+Write-Host "Updating $webAppSiteName redirectUris..." -ForegroundColor Green
+$redirectUris = "https://$webAppSiteName.azurewebsites.net/signin-oidc","https://$webAppSiteName.azurewebsites.net/","https://$webAppSiteName.azurewebsites.net/home/SPHostedAddinEmbedContent"
+Update-MgApplication -ApplicationId $webApp.Id -WebRedirectUris $redirectUris
+
+$appResource = Get-MgApplication -top 400|Where-Object {$_.AppId -eq $armConfigJson.parameters.sourceMockClientId.value}
+$resourceMockWebSiteName = $armConfigJson.parameters.resourceMockWebSiteName.value
+Write-Host "Updating $resourceMockWebSiteName redirectUris..." -ForegroundColor Green
+$redirectUris = "https://$resourceMockWebSiteName.azurewebsites.net/signin-oidc","https://$resourceMockWebSiteName.azurewebsites.net/" 
+Update-MgApplication -ApplicationId $appResource.Id -WebRedirectUris $redirectUris
+
+Write-Host "Completed!" -ForegroundColor Green

--- a/MonetizationCodeSample/PublishSaaSApps.ps1
+++ b/MonetizationCodeSample/PublishSaaSApps.ps1
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [String]$armConfig = "..\Deployment_SaaS_Resources\ARMParameters.json",
+    [Parameter(Mandatory)]
+    [String]$ResourceGroupName
+)
+
+$armConfigJson = Get-Content -Path $armConfig |Out-String|ConvertFrom-Json
+$webAppSiteName = $armConfigJson.parameters.webAppSiteName.value
+$webApiSiteName = $armConfigJson.parameters.webApiSiteName.value
+$resourceMockWebSiteName = $armConfigJson.parameters.resourceMockWebSiteName.value
+
+$currentPath = Get-Location
+
+if (Test-Path .\output){
+    Remove-item .\output -Recurse -Force -Confirm:$false
+}
+
+#publish AppSourceMock
+Write-Host "Building AppSourceMock Site..." -ForegroundColor "Green"
+dotnet publish .\AppSourceMockWebApp\AppSourceMockWebApp.csproj -c Release -o .\output\AppSourceMockWebApp >> log.txt
+
+#publish WebApi
+Write-Host "Building WebApi..." -ForegroundColor "Green"
+dotnet publish .\SaaSSampleWebApi\SaaSSampleWebApi.csproj -c Release -o .\output\SaaSSampleWebApi >> log.txt
+
+#publish WebApp
+Write-Host "Building WebApp..." -ForegroundColor "Green"
+dotnet publish .\SaaSSampleWebApp\SaaSSampleWebApp.csproj -c Release -o .\output\SaaSSampleWebApp >> log.txt
+
+Write-Host "Packing AppSourceMock..." -ForegroundColor "Green"
+Compress-Archive ".\output\AppSourceMockWebApp\*" -DestinationPath ".\output\AppSourceMockWebApp.zip"
+Write-Host "Packing SaaSSampleWebApi..." -ForegroundColor "Green"
+Compress-Archive ".\output\SaaSSampleWebApi\*" -DestinationPath ".\output\SaaSSampleWebApi.zip"
+Write-Host "Packing SaaSSampleWebApp..." -ForegroundColor "Green"
+Compress-Archive ".\output\SaaSSampleWebApp\*" -DestinationPath ".\output\SaaSSampleWebApp.zip"
+try {
+    Write-Host "Publishing AppSourceMock..." -ForegroundColor "Green"
+    Publish-AzWebApp -ResourceGroupName $ResourceGroupName -Name $resourceMockWebSiteName -ArchivePath "$currentPath\output\AppSourceMockWebApp.zip" -Confirm:$false -Force >> log.txt
+    Write-Host "Publishing WebApi..." -ForegroundColor "Green"
+    Publish-AzWebApp -ResourceGroupName $ResourceGroupName -Name $webApiSiteName -ArchivePath "$currentPath\output\SaaSSampleWebApi.zip" -Confirm:$false -Force >> log.txt
+    Write-Host "Publishing WebApp..." -ForegroundColor "Green"
+    Publish-AzWebApp -ResourceGroupName $ResourceGroupName -Name $webAppSiteName -ArchivePath "$currentPath\output\SaaSSampleWebApp.zip" -Confirm:$false -Force >> log.txt
+    Write-Host "Completed!" -ForegroundColor "Green"
+}
+catch {
+    Write-Host $_.Exception.Message
+    Write-Host $_.Exception.ItemName
+}
+


### PR DESCRIPTION
Added a new folder `Deployment_SaaS_Resources` with scripts to deploy only the SaaS resources as below.

AAD apps:
- Contoso Monetization Code Sample Web App
- Contoso Monetization Code Sample Web API
- Contoso Monetization Code Sample App source

And resources needed  for mock app source ,  sample web app and sample web api.

Added a new script file `PublishSaaSApps.ps1` under sample code for publishing the needed application in the `MonetizationCodeSample`